### PR TITLE
Add Kyle Pfister to Contributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -10,3 +10,4 @@ Lydia Fares :D
 Kippen Lee (╯°□°）╯︵ ┻━┻ 
 Jonathan Toussaint ;-)
 Monica Zhang
+Kyle Pfiuster 😊


### PR DESCRIPTION
Added Kyle Pfister to the list of contributors in Contributors.md.